### PR TITLE
Alt parsing

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -40,6 +40,9 @@ pub struct Args {
     /// Compare against installed weidu log, note this is best effort
     #[clap(long, short, action=ArgAction::SetTrue)]
     pub skip_installed: bool,
+
+    #[clap(long, action=ArgAction::SetTrue)]
+    pub stop_on_warnings: bool,
 }
 
 fn parse_absolute_path(arg: &str) -> Result<PathBuf, String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,14 +74,17 @@ fn main() {
             copy_mod_folder(&args.game_directory, mod_folder)
         }
         log::info!("Installing mod {:?}", &weidu_mod);
-        match  install(
+        match install(
             &args.weidu_binary,
             &args.game_directory,
             &weidu_mod,
             &args.language,
         ) {
             InstallationResult::Fail(message) => {
-                panic!("Failed to install mod {}, error is '{}'", weidu_mod.name, message);
+                panic!(
+                    "Failed to install mod {}, error is '{}'",
+                    weidu_mod.name, message
+                );
             }
             InstallationResult::Success => {
                 log::info!("Installed mod {:?}", &weidu_mod);

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,12 +73,18 @@ fn main() {
             );
             copy_mod_folder(&args.game_directory, mod_folder)
         }
-        install(
+        match  install(
             &args.weidu_binary,
             &args.game_directory,
             &weidu_mod,
             &args.language,
-        );
-        log::info!("Installed mod {:?}", &weidu_mod);
+        ) {
+            Err(message) => {
+                panic!("Failed to install mod {}, error is '{}'", weidu_mod.name, message);
+            }
+            Ok(_) => {
+                log::info!("Installed mod {:?}", &weidu_mod);
+            }
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use crate::{
         copy_mod_folder, create_weidu_log_if_not_exists, mod_folder_present_in_game_directory,
         search_mod_folders,
     },
-    weidu::install,
+    weidu::{install, InstallationResult},
 };
 
 mod args;
@@ -73,17 +73,26 @@ fn main() {
             );
             copy_mod_folder(&args.game_directory, mod_folder)
         }
+        log::info!("Installing mod {:?}", &weidu_mod);
         match  install(
             &args.weidu_binary,
             &args.game_directory,
             &weidu_mod,
             &args.language,
         ) {
-            Err(message) => {
+            InstallationResult::Fail(message) => {
                 panic!("Failed to install mod {}, error is '{}'", weidu_mod.name, message);
             }
-            Ok(_) => {
+            InstallationResult::Success => {
                 log::info!("Installed mod {:?}", &weidu_mod);
+            }
+            InstallationResult::Warnings => {
+                if args.stop_on_warnings {
+                    log::info!("Installed mod {:?} with warnings, stopping", &weidu_mod);
+                    break;
+                } else {
+                    log::info!("Installed mod {:?} with warnings, keep going", &weidu_mod);
+                }
             }
         }
     }

--- a/src/weidu.rs
+++ b/src/weidu.rs
@@ -1,7 +1,10 @@
+use core::time;
 use std::{
     io::{self, BufRead, BufReader, Write},
     path::PathBuf,
-    process::{Command, Stdio},
+    process::{Child, ChildStdout, Command, Stdio},
+    sync::mpsc::{self, Receiver, Sender, TryRecvError},
+    thread,
 };
 
 use crate::mod_component::ModComponent;
@@ -16,7 +19,7 @@ pub fn get_user_input() -> String {
 }
 
 fn generate_args(weidu_mod: &ModComponent, language: &str) -> Vec<String> {
-    format!("{mod_name}/{mod_tp_file} --yes --ask-only {component} --use-lang {game_lang} --language {mod_lang}", mod_name = weidu_mod.name, mod_tp_file = weidu_mod.tp_file, component = weidu_mod.component, mod_lang = weidu_mod.lang, game_lang = language).split(' ').map(|x|x.to_string()).collect()
+    format!("{mod_name}/{mod_tp_file} --autolog --force-install {component} --use-lang {game_lang} --language {mod_lang}", mod_name = weidu_mod.name, mod_tp_file = weidu_mod.tp_file, component = weidu_mod.component, mod_lang = weidu_mod.lang, game_lang = language).split(' ').map(|x|x.to_string()).collect()
 }
 
 pub fn install(
@@ -24,111 +27,222 @@ pub fn install(
     game_directory: &PathBuf,
     weidu_mod: &ModComponent,
     language: &str,
-) {
+) -> Result<(), String> {
     let weidu_args = generate_args(weidu_mod, language);
     let mut command = Command::new(weidu_binary);
     let weidu_process = command.current_dir(game_directory).args(weidu_args.clone());
 
-    let mut child = weidu_process
+    let child = weidu_process
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .expect("Failed to spawn weidu process");
 
-    let mut reader = BufReader::new(child.stdout.as_mut().unwrap());
-    let stdin = &mut child.stdin.take().expect("Failed to open stdin");
+    handle_io(child)
+}
 
-    let mut choice_flag = false;
-    let mut failure_flag = false;
-    while child.stderr.is_none() {
-        let mut text = String::new();
-        if reader.read_line(&mut text).is_ok() {
-            if !text.is_empty() && !failure_flag && !choice_flag {
-                log::trace!("{}", text);
-            } else if choice_flag {
-                log::info!("{}", text);
-            } else {
-                log::error!("{}", text);
-            }
+#[derive(Debug)]
+enum ProcessStateChange {
+    RequiresInput { question: String },
+    InProgress,
+    Completed,
+    CompletedWithErrors { error_details: String },
+}
 
-            if text.to_ascii_lowercase().contains("failure") {
-                failure_flag = true;
-            }
+pub fn handle_io(mut child: Child) -> Result<(), String> {
+    let mut writer = child.stdin.take().unwrap();
 
-            if text.contains("Stopping installation because of error.") {
-                log::error!("Weidu process failed with args: {:?}", weidu_args);
-                panic!();
-            }
-
-            match text.clone() {
-                // Choice
-                _ if choice_flag => {
-                    if !text.chars().nth(1).unwrap_or_default().is_numeric() {
-                        stdin
-                            .write_all(get_user_input().as_bytes())
-                            .expect("Failed to write to stdin");
+    let child_state_channel = create_output_reader(child.stdout.take().unwrap());
+    let (parsed_output_sender, parsed_output_receiver) = mpsc::channel::<ProcessStateChange>();
+    parse_output(parsed_output_sender, child_state_channel);
+    let mut wait_counter = 0;
+    loop {
+        match parsed_output_receiver.try_recv() {
+            Ok(   state) => {
+              log::debug!("Current installer state is {:?}", state);
+                match state {
+                    ProcessStateChange::Completed => {
+                        log::debug!("Weidu process completed");
                         break;
                     }
+                    ProcessStateChange::CompletedWithErrors { error_details } => {
+                        log::debug!("Weidu process seem to have completed with errors");
+                        writer
+                            .write("\n".as_bytes())
+                            .expect("Failed to send final ENTER to weidu process");
+                        return Err(error_details);
+                    }
+                    ProcessStateChange::InProgress => {
+                        log::debug!("In progress...");
+                    }
+                    ProcessStateChange::RequiresInput { question } => {
+                        println!("User Input required");
+                        println!("Question is {}", question);
+                        println!("Please do so something!");
+                        let user_input = get_user_input();
+                        println!("");
+                        log::debug!("Read user input {}, sending it to process ", user_input);
+                        writer.write_all(user_input.as_bytes()).unwrap();
+                        log::debug!("Input sent");
+                    }
                 }
-                x if x.starts_with("SKIPPING: ") || x.starts_with("Already Asked About") => {
-                    stdin
-                        .write_all("\n".as_bytes())
-                        .expect("Failed to write to stdin");
-                    log::debug!("Skiping component");
-                    break;
-                }
-                x if (x.trim_end().ends_with("[Q]uit or choose one:")
-                    || x.trim_end().starts_with("Enter "))
-                    && !x.to_ascii_lowercase().starts_with("[r]e-install") =>
-                {
-                    log::info!("{}", text);
-                    log::trace!("Choice found");
-                    choice_flag = true;
-                }
-
-                // Success
-                x if x.contains("SUCCESSFULLY INSTALLED")
-                    || x.starts_with("INSTALLED WITH WARNINGS") =>
-                {
-                    break;
-                }
-
-                // Install
-                x if x.starts_with("Install") => {
-                    log::info!("{}", text);
-                    stdin
-                        .write_all("\n".as_bytes())
-                        .expect("Failed to write to stdin");
-                }
-                x if x.starts_with("[I]nstall") => {
-                    stdin
-                        .write_all("I\n".as_bytes())
-                        .expect("Failed to write to stdin");
-                    log::debug!("Installing");
-                }
-                x if x.to_ascii_lowercase().starts_with("[r]e-install") => {
-                    stdin
-                        .write_all("Q\n".as_bytes())
-                        .expect("Could not quit out");
-                    log::debug!("Continue as already installed");
-                    break;
-                }
-                _ => {}
             }
-        } else {
-            break;
+            Err(TryRecvError::Empty) => {
+                print!("No relevant output from child process, waiting");
+                print!("{}", ".".repeat(wait_counter));
+                wait_counter += 1;
+                wait_counter %= 10;
+                sleep(1000);
+                print!("\r                                              X\r");
+            }
+            Err(TryRecvError::Disconnected) => break,
         }
     }
 
     match child.wait_with_output() {
         Ok(output) if !output.status.success() => {
-            panic!("{:#?}", output);
+            panic!("Something went wrong: {:#?}", output);
         }
         Err(err) => {
             panic!("Did not close properly: {}", err);
         }
-        Ok(output) => {
-            log::trace!("{:#?}", output);
+        Ok(_) => {
+            return Ok(());
         }
     }
+}
+
+#[derive(Debug)]
+enum ParserState {
+    CollectingQuestion,
+    SleepingForQuestionToComplete,
+    LookingForInterestingOutput,
+}
+
+fn parse_output(sender: Sender<ProcessStateChange>, receiver: Receiver<String>) {
+    let mut current_state = ParserState::LookingForInterestingOutput;
+    let mut question = String::new();
+    sender
+        .send(ProcessStateChange::InProgress)
+        .expect("Failed to send process start event");
+    thread::spawn(move || loop {
+        match receiver.try_recv() {
+            Ok(string) => match current_state {
+                ParserState::CollectingQuestion | ParserState::SleepingForQuestionToComplete => {
+                    if string_looks_like_processing(&string)
+                    {
+                        log::debug!("Weidu seems to know an answer for this question");
+                        current_state = ParserState::LookingForInterestingOutput;
+                        question.clear();
+                    } else {
+                        log::debug!("Appending line '{}' to user question", string);
+                        question.push_str(string.as_str());
+                        current_state = ParserState::CollectingQuestion;
+                    }
+                }
+                ParserState::LookingForInterestingOutput => {
+                    let lowercase_string = string.to_lowercase();
+                    if lowercase_string.contains("not installed due to errors")
+                    || lowercase_string.contains("installed with warnings") {
+                        log::debug!("Weidu seems to have encountered errors during isntallation");
+                        sender
+                            .send(ProcessStateChange::CompletedWithErrors { error_details: string.trim().to_string() })
+                            .expect("Failed to send process error event");
+                        break;
+                    } else if string_looks_like_question(&lowercase_string) {
+                        log::debug!(
+                            "Changing parser state to '{:?}' due to line {}",
+                            ParserState::CollectingQuestion,
+                            string
+                        );
+                        current_state = ParserState::CollectingQuestion;
+                        question.push_str(string.as_str());
+                    } else {
+                        log::debug!("Ignoring line {}", string);
+                    }
+                }
+            },
+            Err(TryRecvError::Empty) => {
+                match current_state {
+                    ParserState::CollectingQuestion => {
+                        log::debug!(
+                            "Changing parser state to '{:?}'",
+                            ParserState::SleepingForQuestionToComplete
+                        );
+                        current_state = ParserState::SleepingForQuestionToComplete;
+                    }
+                    ParserState::SleepingForQuestionToComplete => {
+                        log::debug!("No new weidu otput, sending question to user");
+                        sender
+                            .send(ProcessStateChange::RequiresInput {
+                                question: question.clone(),
+                            })
+                            .expect("Failed to send question");
+                        current_state = ParserState::LookingForInterestingOutput;
+                        question.clear();
+                    }
+                    _ => {}
+                }
+                sleep(100);
+            }
+            Err(TryRecvError::Disconnected) => {
+                sender
+                    .send(ProcessStateChange::Completed)
+                    .expect("Failed to send provess end event");
+                break;
+            }
+        }
+    });
+}
+
+fn string_looks_like_question(string: &str) -> bool {
+    let lowercase_string = string.to_lowercase();
+    lowercase_string.contains("choice")
+        || lowercase_string.starts_with("choose")
+        || lowercase_string.starts_with("select")
+        || lowercase_string.starts_with("do you want")
+        || lowercase_string.starts_with("would you like")
+        || lowercase_string.starts_with("enter")
+}
+
+fn string_looks_like_processing(string: &str) -> bool {
+    let lowercase_string = string.to_lowercase();
+    lowercase_string.contains("copying")
+        || lowercase_string.contains("copied")
+        || lowercase_string.contains("installing")
+        || lowercase_string.contains("installed")
+        || lowercase_string.contains("patching")
+        || lowercase_string.contains("patched")
+        || lowercase_string.contains("processing")
+        || lowercase_string.contains("processed")
+        || lowercase_string.ends_with(":\n")
+
+}
+
+fn create_output_reader(out: ChildStdout) -> Receiver<String> {
+    let (tx, rx) = mpsc::channel::<String>();
+    let mut buffered_reader = BufReader::new(out);
+    thread::spawn(move || loop {
+        let mut line = String::new();
+        match buffered_reader.read_line(&mut line) {
+            Ok(0) => {
+                log::debug!("Weidu process ended");
+                break;
+            }
+            Ok(_) => {
+                log::debug!("Got line from weidu: '{}'", line);
+                tx.send(line).expect("Failed to sent process output line");
+            }
+            Err(_) => {
+                tx.send("Error".to_string()).expect("Oops");
+            }
+        }
+    });
+    rx
+}
+
+fn sleep(millis: u64) {
+    let duration = time::Duration::from_millis(millis);
+    thread::sleep(duration);
 }


### PR DESCRIPTION
So, I've got a weidu.log with several hundreds of entries. This PR is the result my attempts to use that log to reinstall EET. It works for me(requires some manual input for mods that use READLN commands though), but I am pretty sure I might have broken some use cases.

Points of interest:
- Changed weidu arguments from `--yes --ask-only {component}` to `--force-install`
  For whatever reason `--yes --ask-only` was not working with dlc-merger for me.
  With `--force-install` though weidu produces the exact same weidu.log as the one that was used as an input.
- Interaction with weidu process is rewritten.
`--force-install` makes it so that inputting `[Y]` is no longer required, but then there is an inherent problem with READLN commands, and I don't think there can be a general solution for that. This implementation seems to mostly work(i.e. works for me) but does not handle the case when user input is incorrect and weidu rejects it.
- Added an option to stop installation if warnings are encountered
- No tests...