### PR TITLE
Bell char from weidu is treated as a question now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,6 +994,7 @@ dependencies = [
  "confy",
  "env_logger",
  "log",
+ "os_pipe",
  "pretty_assertions",
  "reqwest",
  "serde",
@@ -1081,6 +1082,16 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ zip = "^6.0.0"
 
 [dev-dependencies]
 pretty_assertions = "^1.4.1"
+os_pipe = "^1.2.1"

--- a/src/config/parser_config.rs
+++ b/src/config/parser_config.rs
@@ -1,4 +1,4 @@
-use crate::{config::meta::Metadata, state::State};
+use crate::{config::meta::Metadata, state::State };
 
 use serde_derive::{Deserialize, Serialize};
 
@@ -58,6 +58,11 @@ impl Default for ParserConfig {
 }
 
 impl ParserConfig {
+
+    pub fn string_looks_like_weidu_requested_input_explicidly(&self, weidu_output: &str) -> bool {
+        return weidu_output.contains("\x07");
+    }
+
     pub fn string_looks_like_question(&self, weidu_output: &str) -> bool {
         let comparable_output = weidu_output.trim().to_ascii_lowercase();
         // installing|creating
@@ -86,7 +91,7 @@ impl ParserConfig {
             }
         }
 
-        false
+        return self.string_looks_like_weidu_requested_input_explicidly(&weidu_output)
     }
 
     pub fn detect_weidu_finished_state(&self, weidu_output: &str) -> State {
@@ -156,6 +161,7 @@ Example: C:\\Program Files (x86)\\BeamDog\\Games\\00806",
             "[N]o, [Q]uit or choose one:",
             "Please enter the chance for items to randomly not be randomised as a integet number (e.g. 10 for 10%)",
             "Is this correct? [Y]es or [N]o",
+            "There is no question, only bell\x07",
         ];
         for test in tests {
             assert_eq!(

--- a/src/weidu.rs
+++ b/src/weidu.rs
@@ -1,8 +1,8 @@
 use std::{
     error::Error,
-    io::{BufRead, BufReader, ErrorKind, Write},
+    io::{BufReader, Read, Write},
     path::Path,
-    process::{Child, ChildStdout, Command, Stdio},
+    process::{Child, Command, Stdio},
     sync::{
         Arc, RwLock,
         atomic::{AtomicUsize, Ordering},
@@ -180,41 +180,147 @@ pub(crate) fn handle_io(
     Ok(WeiduExitStatus::Success)
 }
 
-fn create_output_reader(out: ChildStdout, log: Arc<RwLock<String>>) -> Receiver<String> {
+fn create_output_reader<R: Read + Send + 'static>(
+    out: R,
+    log: Arc<RwLock<String>>,
+) -> Receiver<String> {
     let (tx, rx) = mpsc::channel::<String>();
     let mut buffered_reader = BufReader::new(out);
     thread::spawn(move || {
+        use std::io::Read;
+
+        let mut byte_buffer_vec: Vec<u8> = Vec::new();
+        let mut single_byte = [0u8; 1];
+
         loop {
-            let mut lines = String::new();
-            match buffered_reader.read_line(&mut lines) {
+            match buffered_reader.read(&mut single_byte) {
                 Ok(0) => {
+                    process_complete_line(&mut byte_buffer_vec, &log, &tx);
                     log::debug!("Process ended");
                     break;
                 }
                 Ok(_) => {
-                    if let Ok(mut writer) = log.write() {
-                        writer.push_str(&lines);
+                    let byte = single_byte[0];
+                    byte_buffer_vec.push(byte);
+                    if byte == b'\n' || byte == 0x07 {
+                        process_complete_line(&mut byte_buffer_vec, &log, &tx);
                     }
-                    lines
-                        .split(LINE_ENDING)
-                        .filter(|line| !line.trim().is_empty())
-                        .for_each(|line| {
-                            log::trace!("Sending: `{line}`");
-                            tx.send(line.to_string())
-                                .expect("Failed to sent process output line");
-                        });
                 }
-                Err(ref e) if e.kind() == ErrorKind::InvalidData => {
-                    // sometimes there is a non-unicode gibberish in process output, it
-                    // does not seem to be an indicator of error or break anything, ignore it
-                    log::warn!("Failed to read weidu output");
-                }
-                Err(details) => {
-                    log::error!("Failed to read process output, error is '{details:?}'");
-                    panic!()
+                Err(e) => {
+                    log::error!("Failed to read process output: {e:?}");
+                    break;
                 }
             }
         }
     });
     rx
+}
+
+fn send_forward(tx: &mpsc::Sender<String>, line: &String) {
+    let trimmed = line.trim();
+    if !trimmed.is_empty() {
+        log::trace!("Sending: `{trimmed}`");
+        tx.send(trimmed.to_string()).expect("Failed to send process output line");
+    }
+}
+
+fn send_to_log(log: &Arc<RwLock<String>>, line: &str) {
+    if !line.is_empty() {
+        if let Ok(mut writer) = log.write() {
+            writer.push_str(line);
+        }
+    }
+}
+
+fn process_complete_line(buffer: &mut Vec<u8>, log: &Arc<RwLock<String>>, tx: &mpsc::Sender<String>) {
+    if buffer.is_empty() {
+        return;
+    }
+
+    let bytes = std::mem::take(buffer);
+    buffer.reserve(128);
+
+    match String::from_utf8(bytes) {
+        Ok(line) => {
+            send_to_log(log, &line);
+            send_forward(tx, &line);
+        }
+        Err(e) => {
+            log::warn!("Failed to convert byte buffer to UTF-8 string: {}", e);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::time::Duration;
+
+    fn test_output_reader(input: &[u8]) -> Vec<String> {
+        let (reader, mut writer) = os_pipe::pipe().unwrap();
+        let log = Arc::new(RwLock::new(String::new()));
+        
+        let rx = create_output_reader(reader, log.clone());
+        
+        writer.write_all(input).unwrap();
+        drop(writer);
+        
+        let mut results = Vec::new();
+        loop {
+            match rx.recv_timeout(Duration::from_secs(1)) {
+                Ok(line) => results.push(line),
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(mpsc::RecvTimeoutError::Timeout) => panic!("Timed out waiting for output"),
+            }
+        }
+        results
+    }
+
+    #[test]
+    fn test_output_reader_with_newline_delimiter() {
+        let results = test_output_reader(b"Hello World\nSecond Line\n");
+        
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0], "Hello World");
+        assert_eq!(results[1], "Second Line");
+    }
+
+    #[test]
+    fn test_output_reader_with_bell_delimiter() {
+        let results = test_output_reader(b"Prompt text\x07More text\x07");
+        
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0], "Prompt text\x07");
+        assert_eq!(results[1], "More text\x07");
+    }
+
+    #[test]
+    fn test_output_reader_with_mixed_delimiters() {
+        let results = test_output_reader(b"Line with newline\nLine with bell\x07Another newline\n");
+        
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0], "Line with newline");
+        assert_eq!(results[1], "Line with bell\x07");
+        assert_eq!(results[2], "Another newline");
+    }
+
+    #[test]
+    fn test_output_reader_with_utf8() {
+        let results = test_output_reader("Hello 🎮 World\nCafé résumé\n".as_bytes());
+        
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0], "Hello 🎮 World");
+        assert_eq!(results[1], "Café résumé");
+    }
+
+    #[test]
+    fn test_output_reader_with_invalid_utf8() {
+        let input = b"Valid line\nInvalid \xFF sequence\nValid again\n";
+        let results = test_output_reader(input);
+        
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0], "Valid line");
+        assert_eq!(results[1], "Valid again");
+    }
 }

--- a/src/weidu_parser.rs
+++ b/src/weidu_parser.rs
@@ -1,4 +1,6 @@
 use std::{
+    collections::VecDeque,
+    mem,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -24,50 +26,75 @@ pub(crate) fn parse_raw_output(
     timeout: usize,
 ) {
     let mut current_state = ParserState::LookingForInterestingOutput;
-    let mut question = String::new();
     sender
         .send(State::InProgress)
         .expect("Failed to send process start event");
     thread::spawn(move || {
+        let mut question = String::new();
+        let messages_to_store = 3;
+        let mut last_few_lines = VecDeque::<String>::with_capacity(messages_to_store);
         loop {
             match receiver.try_recv() {
-                Ok(string) => match current_state {
-                    ParserState::CollectingQuestion
-                    | ParserState::WaitingForMoreQuestionContent => {
-                        if parser_config.useful_status_words.contains(&string) {
-                            log::debug!(
-                                "Weidu seems to know an answer for the last question, ignoring it"
-                            );
-                            current_state = ParserState::LookingForInterestingOutput;
-                            question.clear();
-                        } else {
-                            log::debug!("Appending line '{string}' to user question");
-                            question.push_str(&string);
-                            current_state = ParserState::CollectingQuestion;
+                Ok(string) => {
+                    if last_few_lines.len() == messages_to_store {
+                        last_few_lines.pop_front();
+                    }
+                    last_few_lines.push_back(string.clone());
+
+                    match current_state {
+                        ParserState::CollectingQuestion
+                        | ParserState::WaitingForMoreQuestionContent => {
+                            if parser_config.useful_status_words.contains(&string) {
+                                log::debug!(
+                                    "Weidu seems to know an answer for the last question, ignoring it"
+                                );
+                                current_state = ParserState::LookingForInterestingOutput;
+                                question.clear();
+                            } else {
+                                log::debug!("Appending line '{string}' to user question");
+                                question.push_str(&string);
+                                current_state = ParserState::CollectingQuestion;
+                            }
+                        }
+                        ParserState::LookingForInterestingOutput => {
+                            let installer_state =
+                                parser_config.detect_weidu_finished_state(&string);
+                            if installer_state != State::InProgress {
+                                sender
+                                    .send(installer_state)
+                                    .expect("Failed to send process error event");
+                                break;
+                            }
+                            if parser_config
+                                .string_looks_like_weidu_requested_input_explicidly(&string)
+                            {
+                                let prev_lines = last_few_lines.drain(..).fold(
+                                    String::new(),
+                                    |mut acc, chunk| {
+                                        acc.push_str(&chunk);
+
+                                        acc
+                                    },
+                                );
+                                log::warn!(
+                                    "Weidu unexpectedly requested input, sending previous lines to user",
+                                );
+                                send_question_to_user(&sender, &mut current_state, prev_lines);
+                            } else if parser_config.string_looks_like_question(&string) {
+                                log::debug!(
+                                    "Changing parser state to '{:?}' due to line {}",
+                                    ParserState::CollectingQuestion,
+                                    string
+                                );
+                                current_state = ParserState::CollectingQuestion;
+                                question.push_str(string.as_str());
+                            }
+                            if !string.trim().is_empty() {
+                                log::trace!("{string}");
+                            }
                         }
                     }
-                    ParserState::LookingForInterestingOutput => {
-                        let installer_state = parser_config.detect_weidu_finished_state(&string);
-                        if installer_state != State::InProgress {
-                            sender
-                                .send(installer_state)
-                                .expect("Failed to send process error event");
-                            break;
-                        }
-                        if parser_config.string_looks_like_question(&string) {
-                            log::debug!(
-                                "Changing parser state to '{:?}' due to line {}",
-                                ParserState::CollectingQuestion,
-                                string
-                            );
-                            current_state = ParserState::CollectingQuestion;
-                            question.push_str(string.as_str());
-                        }
-                        if !string.trim().is_empty() {
-                            log::trace!("{string}");
-                        }
-                    }
-                },
+                }
                 Err(TryRecvError::Empty) => match current_state {
                     ParserState::CollectingQuestion => {
                         log::debug!(
@@ -78,11 +105,11 @@ pub(crate) fn parse_raw_output(
                     }
                     ParserState::WaitingForMoreQuestionContent => {
                         log::debug!("No new weidu output, sending question to user");
-                        sender
-                            .send(State::RequiresInput { question })
-                            .expect("Failed to send question");
-                        current_state = ParserState::LookingForInterestingOutput;
-                        question = String::new();
+                        send_question_to_user(
+                            &sender,
+                            &mut current_state,
+                            mem::take(&mut question),
+                        );
                     }
                     _ if wait_count.load(Ordering::Relaxed) >= timeout => {
                         sender
@@ -100,4 +127,15 @@ pub(crate) fn parse_raw_output(
             }
         }
     });
+}
+
+fn send_question_to_user(
+    sender: &Sender<State>,
+    current_state: &mut ParserState,
+    question: String,
+) {
+    sender
+        .send(State::RequiresInput { question: question })
+        .expect("Failed to send question");
+    *current_state = ParserState::LookingForInterestingOutput;
 }


### PR DESCRIPTION
Support this **truly brilliant** idea from the other size:

https://github.com/The-Mod-Elephant/weidu/pull/23

Actually, this is sort of a draft - detecting weidu prompts by parsing mod output is unreliable, so adding(and reacting) to bell character sounds like an interesting compromise that establishes sort of common interface between tools, does not need any switches or flags on weidu side, does not produce any visible output that might confuse user and also provides some additional usability to weidu users.